### PR TITLE
Only Process most recent POST request to service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "stylers",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3061,12 +3060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,9 +3142,6 @@ name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "local-channel"
@@ -5064,18 +5054,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "stylers"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e306edf4b3cb5cff4b2e21b8895ed9e70fbd1bbb3a8dfb7e4cc245a763a955"
-dependencies = [
- "levenshtein",
- "litrs",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "subtle"

--- a/heatmap-client/src/canvas/mod.rs
+++ b/heatmap-client/src/canvas/mod.rs
@@ -62,12 +62,7 @@ pub fn Canvas() -> impl IntoView {
         .expect("ERROR: Failed to get external state")
         .attr("class", "wgpu_surface");
 
-    let (active_requests, set_active_requests) = create_signal(0);
-    let data_loader = DataLoader {
-        event_loop_proxy,
-        active_requests,
-        set_active_requests,
-    };
+    let data_loader = DataLoader::new(event_loop_proxy);
 
     create_effect(move |_| data_loader.load_data(filter()));
 

--- a/heatmap-client/src/canvas/mod.rs
+++ b/heatmap-client/src/canvas/mod.rs
@@ -62,7 +62,12 @@ pub fn Canvas() -> impl IntoView {
         .expect("ERROR: Failed to get external state")
         .attr("class", "wgpu_surface");
 
-    let data_loader = DataLoader { event_loop_proxy };
+    let (active_requests, set_active_requests) = create_signal(0);
+    let data_loader = DataLoader {
+        event_loop_proxy,
+        active_requests,
+        set_active_requests,
+    };
 
     create_effect(move |_| data_loader.load_data(filter()));
 

--- a/heatmap-client/src/ingest/load.rs
+++ b/heatmap-client/src/ingest/load.rs
@@ -4,6 +4,7 @@ use std::collections::VecDeque;
 use geo::geometry::{Coord, LineString, Polygon};
 use geo::{coord, Simplify, TriangulateEarcut};
 use heatmap_api::{HeatmapData, OutlineResponse};
+use leptos::{SignalGetUntracked, SignalUpdate};
 use winit::event_loop::EventLoopProxy;
 
 use super::request::request;
@@ -24,43 +25,59 @@ pub struct BufferStorage {
 
 pub struct DataLoader {
     pub event_loop_proxy: EventLoopProxy<UserMessage<'static>>,
+    pub active_requests: leptos::ReadSignal<u32>,
+    pub set_active_requests: leptos::WriteSignal<u32>,
 }
 
 impl DataLoader {
     pub fn load_data(&self, filter: heatmap_api::Filter) {
-        leptos::spawn_local(load_data_async(self.event_loop_proxy.clone(), filter));
+        self.set_active_requests.update(|n| *n += 1);
+        leptos::spawn_local(load_data_async(
+            self.event_loop_proxy.clone(),
+            filter,
+            self.active_requests,
+            self.set_active_requests,
+        ));
     }
 }
 
 async fn load_data_async(
     event_loop_proxy: EventLoopProxy<UserMessage<'static>>,
     filter: heatmap_api::Filter,
+    active_requests: leptos::ReadSignal<u32>,
+    set_active_requests: leptos::WriteSignal<u32>,
 ) {
     // Request data from the server
     let (data, outline_data) = request(filter).await;
 
-    // Convert the data into a triangular mesh
-    web_sys::console::log_1(&"Meshing data...".into());
-    let meshed_data = mesh_data(Data::Heatmap(data));
-    let meshed_outline_data = mesh_data(Data::Outline(outline_data));
-    web_sys::console::log_3(
-        &"Meshed Data: \n".into(),
-        &format!(
-            "Vertices: {:?}",
-            meshed_data.first().expect("Empty meshed data").vertices
-        )
-        .into(),
-        &format!(
-            "Indices: {:?}",
-            meshed_data.first().expect("no indices").indices
-        )
-        .into(),
+    web_sys::console::log_1(
+        &format!("Active Requests: {:?}", active_requests.get_untracked()).into(),
     );
+    // Convert the data into a triangular mesh
+    if active_requests.get_untracked() == 1 {
+        web_sys::console::log_1(&"Meshing data...".into());
+        let meshed_data = mesh_data(Data::Heatmap(data));
+        let meshed_outline_data = mesh_data(Data::Outline(outline_data));
+        web_sys::console::log_3(
+            &"Meshed Data: \n".into(),
+            &format!(
+                "Vertices: {:?}",
+                meshed_data.first().expect("Empty meshed data").vertices
+            )
+            .into(),
+            &format!(
+                "Indices: {:?}",
+                meshed_data.first().expect("no indices").indices
+            )
+            .into(),
+        );
 
-    // Send the triangular mesh to the event loop
-    web_sys::console::log_1(&"Sending Mesh to event loop".into());
-    let _ =
-        event_loop_proxy.send_event(UserMessage::IncomingData(meshed_data, meshed_outline_data));
+        // Send the triangular mesh to the event loop
+        web_sys::console::log_1(&"Sending Mesh to event loop".into());
+        let _ = event_loop_proxy
+            .send_event(UserMessage::IncomingData(meshed_data, meshed_outline_data));
+    }
+    set_active_requests.update(|n| *n -= 1);
 }
 
 fn mesh_data(data_exterior: Data) -> Vec<BufferStorage> {

--- a/heatmap-client/src/ingest/load.rs
+++ b/heatmap-client/src/ingest/load.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use geo::geometry::{Coord, LineString, Polygon};
 use geo::{coord, Simplify, TriangulateEarcut};
 use heatmap_api::{HeatmapData, OutlineResponse};
-use leptos::{SignalGetUntracked, SignalUpdate};
+use leptos::{create_signal, SignalGetUntracked, SignalUpdate};
 use winit::event_loop::EventLoopProxy;
 
 use super::request::request;
@@ -30,6 +30,15 @@ pub struct DataLoader {
 }
 
 impl DataLoader {
+    pub fn new(event_loop_proxy: EventLoopProxy<UserMessage<'static>>) -> Self {
+        let (active_requests, set_active_requests) = create_signal(0);
+
+        DataLoader {
+            event_loop_proxy,
+            active_requests,
+            set_active_requests,
+        }
+    }
     pub fn load_data(&self, filter: heatmap_api::Filter) {
         self.set_active_requests.update(|n| *n += 1);
         leptos::spawn_local(load_data_async(

--- a/heatmap-client/src/main.rs
+++ b/heatmap-client/src/main.rs
@@ -15,6 +15,7 @@ mod ui;
 fn main() {
     console_error_panic_hook::set_once();
 
+    // Default filter, used on startup
     let (filter, set_filter) = create_signal(heatmap_api::Filter {
         product_type: vec![
             heatmap_api::ProductTypes::GroundRangeDetected,
@@ -34,7 +35,6 @@ fn main() {
             .format("%Y-%m-%d")
             .to_string(),
     });
-
     provide_context(filter);
 
     let app = view! {


### PR DESCRIPTION
We now only process the most recent POST request to the heatmap service, this only comes into play if 2 or more requests have been made and we have not received a response from either.

DataLoader in load.rs now stores a leptos signal which tracks the number of active requests at any given point.