### PR TITLE
Transition heatmap granule encoding to binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2281,7 @@ dependencies = [
 name = "heatmap-api"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "chrono",
  "leptos",
  "serde",
@@ -2273,6 +2294,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "base64 0.22.1",
+ "bincode",
  "bytemuck",
  "cgmath",
  "chrono",
@@ -2308,6 +2330,7 @@ dependencies = [
  "actix-web",
  "approx 0.5.1",
  "base64 0.13.1",
+ "bincode",
  "chrono",
  "config 0.13.4",
  "deadpool-redis",
@@ -3157,7 +3180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -5777,6 +5800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5887,6 +5916,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "waker-fn"

--- a/heatmap-api/Cargo.toml
+++ b/heatmap-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bincode = "2.0.1"
 chrono = "0.4.38"
 leptos = "0.6.12"
 serde = "1.0.204"

--- a/heatmap-api/src/lib.rs
+++ b/heatmap-api/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use bincode::{Encode, Decode};
 
 pub trait ToPartialString {
     fn _to_partial_string(&self) -> String;
@@ -76,16 +77,16 @@ pub struct HeatmapQuery {
 
 // Server sends this back to client after a query,
 // contains the granule data
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Decode, Encode, Deserialize, Serialize, Debug, PartialEq)]
 pub struct HeatmapResponse {
     pub data: HeatmapData,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Encode, Decode, Deserialize, Serialize, Debug, PartialEq)]
 pub struct HeatmapData {
     pub data: InteriorData,
 }
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Encode, Decode, Deserialize, Serialize, Debug, PartialEq)]
 pub struct InteriorData {
     pub length: i32,
     pub positions: Vec<Vec<(f64, f64)>>,

--- a/heatmap-api/src/lib.rs
+++ b/heatmap-api/src/lib.rs
@@ -1,5 +1,5 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
-use bincode::{Encode, Decode};
 
 pub trait ToPartialString {
     fn _to_partial_string(&self) -> String;

--- a/heatmap-client/Cargo.toml
+++ b/heatmap-client/Cargo.toml
@@ -33,6 +33,7 @@ png = "0.17.13"
 urlencoding = "2.1.3"
 base64 = "0.22.1"
 text-to-png = "0.2.0"
+bincode = "2.0.1"
 
 [lints.clippy]
 unwrap_used = "warn"

--- a/heatmap-client/src/canvas/app.rs
+++ b/heatmap-client/src/canvas/app.rs
@@ -149,7 +149,7 @@ impl ApplicationHandler<UserMessage<'static>> for App<'_> {
                 web_sys::console::log_1(&"Assign state values in application handler...".into());
 
                 self.state = State {
-                    render_context: Some(render_context),
+                    render_context: Some(*render_context),
                     window: self.state.window.clone(),
                     init_stage: InitStage::Complete,
                     geometry: None,
@@ -339,9 +339,9 @@ impl ApplicationHandler<UserMessage<'static>> for App<'_> {
         }
     }
 }
-// All user events that can be sent to the event loop
+/// All user events that can be sent to the event loop
 pub enum UserMessage<'a> {
-    StateMessage(RenderContext<'a>),
+    StateMessage(Box<RenderContext<'a>>),
     IncomingData(Vec<BufferStorage>, Vec<BufferStorage>),
     MaxWeightMapped,
     ExportMapped,

--- a/heatmap-client/src/canvas/app.rs
+++ b/heatmap-client/src/canvas/app.rs
@@ -106,7 +106,7 @@ impl ApplicationHandler<UserMessage<'static>> for App<'_> {
                             self.exiting(event_loop);
                         }
 
-                        Err(e) => eprintln!("{:?}", e),
+                        Err(e) => eprintln!("{e:?}",),
                     }
                 }
 
@@ -256,7 +256,7 @@ impl ApplicationHandler<UserMessage<'static>> for App<'_> {
                     }
                 }
 
-                web_sys::console::log_1(&format!("Max: {:?}", max).into());
+                web_sys::console::log_1(&format!("Max: {max:?}").into());
 
                 // We now update the uniform buffer with our max weight
                 //    so that we can read the max value in the colormap render pass
@@ -314,7 +314,7 @@ impl ApplicationHandler<UserMessage<'static>> for App<'_> {
                         .base64_png = Some(base64_encoded_png.clone());
                 }
 
-                web_sys::console::log_1(&format!("PNG Bytes: {:X?}", base64_encoded_png).into());
+                web_sys::console::log_1(&format!("PNG Bytes: {base64_encoded_png:X?}").into());
 
                 // We dynamically generate this anchor element to download the generated png, it is removed after it goes out of scope
                 {

--- a/heatmap-client/src/canvas/geometry.rs
+++ b/heatmap-client/src/canvas/geometry.rs
@@ -102,7 +102,7 @@ fn gen_lod_layers(
             render_context
                 .device
                 .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some(&(format!("{:?} LOD {:?} Vertex Buffer", label, i))),
+                    label: Some(&(format!("{label:?} LOD {i:?} Vertex Buffer"))),
                     contents: bytemuck::cast_slice(layer.vertices.as_slice()),
                     usage: wgpu::BufferUsages::VERTEX,
                 });
@@ -111,7 +111,7 @@ fn gen_lod_layers(
             render_context
                 .device
                 .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some(&(format!("{:?} LOD {:?} Index Buffer", label, i))),
+                    label: Some(&(format!("{label:?} LOD {i:?} Index Buffer"))),
                     contents: bytemuck::cast_slice(layer.indices.as_slice()),
                     usage: wgpu::BufferUsages::INDEX,
                 });

--- a/heatmap-client/src/canvas/png.rs
+++ b/heatmap-client/src/canvas/png.rs
@@ -27,7 +27,7 @@ pub fn generate_heatmap_image(render_context: &mut RenderContext, filter: Filter
         color_data.push(f32::from_le_bytes([*raw[0], *raw[1], *raw[2], *raw[3]]));
     }
 
-    web_sys::console::log_1(&format!("Freshley decoded: {:?}", color_data).into());
+    web_sys::console::log_1(&format!("Freshley decoded: {color_data:?}").into());
 
     // Convert the raw image data into an ImageBuffer that can be saved, must use copy texture width here,
     //     Copy Texture is 256 byte aligned so copy_texture.width() is larger than displayed size and so
@@ -168,9 +168,7 @@ pub fn generate_export_image(
         last_upper = upper;
         layer += 1;
 
-        web_sys::console::log_1(
-            &format!("Upper: {:?}\nRunning Total: {:?}", upper, last_upper).into(),
-        );
+        web_sys::console::log_1(&format!("Upper: {upper:?}\nRunning Total: {last_upper:?}").into());
     }
 
     // Last range in legend, formatting is unique so it cant be done in the loop

--- a/heatmap-client/src/canvas/render_context.rs
+++ b/heatmap-client/src/canvas/render_context.rs
@@ -197,7 +197,7 @@ pub async fn generate_render_context(
     web_sys::console::log_1(&"Done Generating State".into());
     // Because this is a wasm application we cannot block on async calls so we instead send a message
     //    back to the application handler when this function completes
-    let _ = event_loop_proxy.send_event(UserMessage::StateMessage(message));
+    let _ = event_loop_proxy.send_event(UserMessage::StateMessage(Box::new(message)));
 }
 
 /// Contains a texture and buffer used to map a texture onto the CPU

--- a/heatmap-client/src/canvas/state.rs
+++ b/heatmap-client/src/canvas/state.rs
@@ -85,7 +85,7 @@ impl State<'_> {
             render_context.export_texture_context =
                 generate_export_texture(&render_context.device, new_size);
 
-            web_sys::console::log_1(&format!("New Size: {:?}", new_size).into());
+            web_sys::console::log_1(&format!("New Size: {new_size:?}").into());
         }
     }
 

--- a/heatmap-client/src/ingest/request.rs
+++ b/heatmap-client/src/ingest/request.rs
@@ -12,17 +12,15 @@ pub async fn request(filter: heatmap_api::Filter) -> (HeatmapData, OutlineRespon
         .await
         .expect("ERROR: Failed to recive data from post request");
 
-    // Deserialize response into json string
-    let str = data
-        .text()
-        .await
-        .expect("ERROR: Failed to deserialize Response into json str");
+    // Deserialize response into bytes
+    let res_bytes = data.bytes().await.unwrap();
 
-    web_sys::console::log_2(&"Data text: ".into(), &format!("{:?}", str).into());
+    web_sys::console::log_2(&"Data text: ".into(), &format!("{:?}", res_bytes).into());
 
     // Convert json string into a HeatmapData struct
-    let json_data: heatmap_api::HeatmapData =
-        serde_json::from_str(&str).expect("ERROR: Failed to deserialized json data");
+    let heatmap_data:(HeatmapData, usize) =
+        bincode::decode_from_slice(&res_bytes.to_vec(), bincode::config::standard()).expect("ERROR: Failed to deserialized json data");
+
 
     // Get the outline data from the service
     // *** This should be broken out into its own function so we only get and mesh the world outline once ***
@@ -40,5 +38,5 @@ pub async fn request(filter: heatmap_api::Filter) -> (HeatmapData, OutlineRespon
 
     // Deserialize the json into a HeatmapData struct
     web_sys::console::log_1(&"Data succesfully deserialized".into());
-    (json_data, outline_data)
+    (heatmap_data.0, outline_data)
 }

--- a/heatmap-service/Cargo.toml
+++ b/heatmap-service/Cargo.toml
@@ -29,3 +29,4 @@ serde_with = "2.0.0"
 heatmap-api = { path = "../heatmap-api" }
 rust-embed = "8.5.0"
 rayon = "1.10.0"
+bincode = "2.0.1"

--- a/heatmap-service/src/heatmap_data.rs
+++ b/heatmap-service/src/heatmap_data.rs
@@ -1,8 +1,9 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::granule::Granule;
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Decode, Encode, Debug, PartialEq)]
 pub struct HeatmapData {
     pub length: i32,
     pub positions: Vec<Vec<(f64, f64)>>,

--- a/heatmap-service/src/heatmap_response.rs
+++ b/heatmap-service/src/heatmap_response.rs
@@ -1,10 +1,11 @@
+use bincode::{Decode, Encode};
 use chrono::NaiveDate;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{granule::Granule, heatmap_data::HeatmapData};
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Decode, Encode, Debug, PartialEq)]
 pub struct HeatmapResponse {
     pub data: HeatmapData,
 }

--- a/heatmap-service/src/main.rs
+++ b/heatmap-service/src/main.rs
@@ -53,7 +53,7 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         let cors = Cors::default()
             .allowed_origin("https://asfadmin.github.io") // The client is hosted on github pages
-            .allowed_origin("localhost") // Allowed for debug purposes
+            .allowed_origin("http://localhost:8080") // Allowed for debug purposes
             .allowed_methods(vec!["GET", "POST"])
             .allowed_headers(vec![header::AUTHORIZATION, header::ACCEPT])
             .allowed_header(header::CONTENT_TYPE)

--- a/heatmap-service/src/query.rs
+++ b/heatmap-service/src/query.rs
@@ -1,4 +1,5 @@
 use actix_web::{
+    body::BoxBody,
     web::{Data, Json},
     Error, HttpRequest, HttpResponse,
 };
@@ -38,7 +39,11 @@ async fn heatmap_query(
 
     let response_data = HeatmapResponse::from_geojson(query.filter, feature_collection);
 
-    let response = HttpResponse::Ok().json(&response_data);
+    let response = HttpResponse::Ok()
+        .message_body(BoxBody::new(
+            bincode::encode_to_vec(&response_data, bincode::config::standard()).unwrap(),
+        ))
+        .expect("Failed to create HttpResponse for heatmap granules");
 
     if let Some(redis_pool) = redis_wrapped {
         redis::cache_put(


### PR DESCRIPTION
Heatmap Granule data is currently being sent to the client as a json string. By switching this encoding to binary using bincode we can dramatically reduce the size of transferred data.

- Updated heatmap-client/src/ingest/request.rs
    - Swapped serde_json::from_str to bincode::decode_from_slice
    - Tidied up code for requesting heatmap granule data
- Updated heatmap-servcie/src/query.rs
    - Swapped Serde Serialize to use Bincode Encode. Serde Serialize and Deserialize traits are still implemented as the redis cache relies on them, something that I will look into fixing if I have time